### PR TITLE
add Cyprus country code for TCS

### DIFF
--- a/lib/ndfl_dividents.ex
+++ b/lib/ndfl_dividents.ex
@@ -125,6 +125,10 @@ defmodule NdflDividents do
     "372"
   end
 
+  defp country_to_filed("Кипр") do
+    "196"
+  end
+
   defp csv_row_to_map([
          _,
          date,


### PR DESCRIPTION
Спасибо за программу!
Добавил Кипр для TCS, без этого падало.
По какой причине в одном поле не проставило не выплачивать вычет, но лень дебажить было. Вручную дозаполнил и оправил.