### PR TITLE
Add Switzerland and Russian codes

### DIFF
--- a/lib/ndfl_dividents.ex
+++ b/lib/ndfl_dividents.ex
@@ -137,6 +137,14 @@ defmodule NdflDividents do
     "344"
   end
 
+  defp country_to_filed("Швейцарская Конфедерация") do
+    "756"
+  end
+
+  defp country_to_filed("РОССИЯ") do
+    "643"
+  end
+
   defp csv_row_to_map([
          _,
          date,


### PR DESCRIPTION
Спасибо за программу - сэкономил кучу времени =)

Россия добавлена чтобы приложение не падало на "Американская депозитарная расписка на ао ПАО "МТС" - РОССИЯ - затем можно удалить запись

потом уже увидел PR1 и aryadev@efb3de0 - 1 строка на код страны все же лучше